### PR TITLE
Introduce async/await, prepare for wolkenkit 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Since this template does not contain a complete application, you can't run it di
 
 ## License
 
-Copyright (c) 2017 the native web.
+Copyright (c) 2017-2018 the native web.
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "wolkenkit": {
     "application": "sample",
     "runtime": {
-      "version": "1.2.0"
+      "version": "2.0.0"
     },
     "environments": {
       "default": {

--- a/server/flows/sampleFlow.js
+++ b/server/flows/sampleFlow.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const when = {
-  'sampleContext.sampleAggregate.sampleEvent' (event, mark) {
+  async 'sampleContext.sampleAggregate.sampleEvent' (event) {
     // ...
-
-    mark.asDone();
   }
 };
 

--- a/server/readModel/lists/sampleList.js
+++ b/server/readModel/lists/sampleList.js
@@ -5,12 +5,10 @@ const fields = {
 };
 
 const when = {
-  'sampleContext.sampleAggregate.sampleEvent' (sampleList, event, mark) {
+  async 'sampleContext.sampleAggregate.sampleEvent' (sampleList, event) {
     sampleList.add({
       // ...
     });
-
-    mark.asDone();
   }
 };
 

--- a/server/writeModel/sampleContext/sampleAggregate.js
+++ b/server/writeModel/sampleContext/sampleAggregate.js
@@ -13,12 +13,10 @@ const initialState = {
 };
 
 const commands = {
-  sampleCommand (sampleAggregate, command, mark) {
+  async sampleCommand (sampleAggregate, command) {
     sampleAggregate.events.publish('sampleEvent', {
       // ...
     });
-
-    mark.asDone();
   }
 };
 


### PR DESCRIPTION
Hi @mattwagl 😊 

This PR introduces `async`/`await`, and updates the runtime to wolkenkit 2.
Can you please review and squash/merge it, **once wolkenkit 2 is available**?